### PR TITLE
fix rotp >=5.0

### DIFF
--- a/lib/active_model/one_time_password.rb
+++ b/lib/active_model/one_time_password.rb
@@ -48,7 +48,12 @@ module ActiveModel
           end
           result
         else
-          totp = ROTP::TOTP.new(otp_column, digits: otp_digits)
+          val = options[:interval]
+          if val.present?
+            totp = ROTP::TOTP.new(otp_column, {interval: val, digits: otp_digits})
+          else
+            totp = ROTP::TOTP.new(otp_column, digits: otp_digits)
+          end
           if drift = options[:drift]
             totp.verify(code, drift_behind: drift)
           else
@@ -70,7 +75,12 @@ module ActiveModel
           else
             time = options
           end
-          ROTP::TOTP.new(otp_column, digits: otp_digits).at(time)
+          val = options[:interval]
+          if val.present?
+            ROTP::TOTP.new(otp_column, {interval: val, digits: otp_digits}).at(time)
+          else
+            ROTP::TOTP.new(otp_column, digits: otp_digits).at(time)
+          end
         end
       end
 

--- a/lib/active_model/one_time_password.rb
+++ b/lib/active_model/one_time_password.rb
@@ -31,7 +31,7 @@ module ActiveModel
 
     module InstanceMethodsOnActivation
       def otp_regenerate_secret
-        self.otp_column = ROTP::Base32.random_base32
+        self.otp_column = ROTP::Base32.random
       end
 
       def otp_regenerate_counter


### PR DESCRIPTION
升级到rails 5.0.1后，提示 `ROTP::Base32.random_base32` 没有，翻[官方](https://github.com/mdp/rotp.git) 找到以下说明，改之

不知道能否向下兼容

```
Breaking changes in >= 5.0
ROTP::Base32.random_base32 is now ROTP::Base32.random and the argument has changed from secret string length to byte length to allow for more precision
Cleaned up the Base32 implementation to better match Google Authenticator's version
```